### PR TITLE
既存のトラッカーの座標系に追加する機能を追加

### DIFF
--- a/vmt_driver/CommunicationManager.h
+++ b/vmt_driver/CommunicationManager.h
@@ -29,7 +29,7 @@ namespace VMTDriver {
 
 	class OSCReceiver : public osc::OscPacketListener {
 	private:
-		void SetPose(bool roomToDriver,int idx, int enable, double x, double y, double z, double qx, double qy, double qz, double qw, double timeoffset);
+		void SetPose(bool roomToDriver, int idx, int enable, double x, double y, double z, double qx, double qy, double qz, double qw, double timeoffset, int root_sn = 0);
 		virtual void ProcessMessage(const osc::ReceivedMessage& m, const IpEndpointName& remoteEndpoint);
 	public:
 		static void OSCReceiver::SendLog(int stat, string msg);


### PR DESCRIPTION
例えば、Viveトラッカーの周辺機器などを作成するときに、
周辺機器自身がポジショニングシステムを持たなくても、
Viveトラッカーからの相対位置（固定位置関係）を指定することで
仮想トラッカーとして動作させることが可能になります。