### PR TITLE
Jointモードでトラッカーを追加する際に、Rotationの取り扱い方にモードを追加

### DIFF
--- a/vmt_driver/CommunicationManager.cpp
+++ b/vmt_driver/CommunicationManager.cpp
@@ -30,7 +30,7 @@ SOFTWARE.
 
 namespace VMTDriver {
 	//•ÊƒXƒŒƒbƒh
-	void OSCReceiver::SetPose(bool roomToDriver, int idx, int enable, double x, double y, double z, double qx, double qy, double qz, double qw, double timeoffset, const char* root_sn)
+	void OSCReceiver::SetPose(bool roomToDriver, int idx, int enable, double x, double y, double z, double qx, double qy, double qz, double qw, double timeoffset, int jointMode, const char* root_sn)
 	{
 		RawPose pose;
 		pose.roomToDriver = roomToDriver;
@@ -44,6 +44,7 @@ namespace VMTDriver {
 		pose.qz = qz;
 		pose.qw = qw;
 		pose.timeoffset = timeoffset;
+		pose.jointMode = jointMode;
 		pose.root_sn = root_sn;
 
 		ServerTrackedDeviceProvider* sever = CommunicationManager::GetInstance()->GetServer();
@@ -138,25 +139,25 @@ namespace VMTDriver {
 			}
 			else if (adr == "/VMT/Joint/Unity")
 			{
-				int idx, enable;
+				int idx, enable, jointMode;
 				float timeoffset;
 				float x, y, z, qx, qy, qz, qw;
 				const char* root_sn = nullptr;
 				osc::ReceivedMessageArgumentStream args = m.ArgumentStream();
-				args >> idx >> enable >> timeoffset >> x >> y >> z >> qx >> qy >> qz >> qw >> root_sn >> osc::EndMessage;
+				args >> idx >> enable >> timeoffset >> x >> y >> z >> qx >> qy >> qz >> qw >> jointMode >> root_sn >> osc::EndMessage;
 
-				SetPose(false, idx, enable, x, y, -z, qx, qy, -qz, -qw, timeoffset, root_sn);
+				SetPose(false, idx, enable, x, y, -z, qx, qy, -qz, -qw, timeoffset, jointMode, root_sn);
 			}
 			else if (adr == "/VMT/Joint/Driver")
 			{
-				int idx, enable;
+				int idx, enable, jointMode;
 				float timeoffset;
 				float x, y, z, qx, qy, qz, qw;
 				const char* root_sn = nullptr;
 				osc::ReceivedMessageArgumentStream args = m.ArgumentStream();
-				args >> idx >> enable >> timeoffset >> x >> y >> z >> qx >> qy >> qz >> qw >> root_sn >> osc::EndMessage;
+				args >> idx >> enable >> timeoffset >> x >> y >> z >> qx >> qy >> qz >> qw >> jointMode >> root_sn >> osc::EndMessage;
 
-				SetPose(false, idx, enable, x, y, z, qx, qy, qz, qw, timeoffset, root_sn);
+				SetPose(false, idx, enable, x, y, z, qx, qy, qz, qw, timeoffset, jointMode, root_sn);
 			}
 			else if (adr == "/VMT/Input/Button")
 			{

--- a/vmt_driver/CommunicationManager.cpp
+++ b/vmt_driver/CommunicationManager.cpp
@@ -29,7 +29,7 @@ SOFTWARE.
 #include "DirectOSC.h"
 
 namespace VMTDriver {
-	//•ÊƒXƒŒƒbƒh
+	//åˆ¥ã‚¹ãƒ¬ãƒƒãƒ‰
 	void OSCReceiver::SetPose(bool roomToDriver, int idx, int enable, double x, double y, double z, double qx, double qy, double qz, double qw, double timeoffset, int jointMode, const char* root_sn)
 	{
 		RawPose pose;
@@ -44,7 +44,7 @@ namespace VMTDriver {
 		pose.qz = qz;
 		pose.qw = qw;
 		pose.timeoffset = timeoffset;
-		pose.jointMode = jointMode;
+		pose.jointMode = static_cast<JointMode_t>(jointMode);
 		pose.root_sn = root_sn;
 
 		ServerTrackedDeviceProvider* server = CommunicationManager::GetInstance()->GetServer();
@@ -92,7 +92,7 @@ namespace VMTDriver {
 	}
 
 
-	//•ÊƒXƒŒƒbƒh
+	//åˆ¥ã‚¹ãƒ¬ãƒƒãƒ‰
 	void OSCReceiver::ProcessMessage(const osc::ReceivedMessage& m, const IpEndpointName& remoteEndpoint)
 	{
 		try {
@@ -203,11 +203,11 @@ namespace VMTDriver {
 			}
 			else if (adr == "/VMT/Reset")
 			{
-				//‘Sƒgƒ‰ƒbƒJ[‚ð0‚É‚·‚é
+			//å…¨ãƒˆãƒ©ãƒƒã‚«ãƒ¼ã‚’0ã«ã™ã‚‹
 				ServerTrackedDeviceProvider* sever = CommunicationManager::GetInstance()->GetServer();
 				for (int i = 0; i < sever->GetDevices().size(); i++)
 				{
-					sever->GetDevices()[i].Reset(); //‚·‚Å‚ÉVRƒVƒXƒeƒ€‚É“o˜^Ï‚Ý‚Ì‚à‚Ì‚¾‚¯’Ê’m‚³‚ê‚é
+					sever->GetDevices()[i].Reset(); //ã™ã§ã«VRã‚·ã‚¹ãƒ†ãƒ ã«ç™»éŒ²æ¸ˆã¿ã®ã‚‚ã®ã ã‘é€šçŸ¥ã•ã‚Œã‚‹
 				}
 			}
 			else if (adr == "/VMT/LoadSetting")
@@ -344,7 +344,7 @@ namespace VMTDriver {
 	}
 	void CommunicationManager::Process()
 	{
-		//’èŠú“I‚É¶‘¶M†‚ð‘—M
+		//å®šæœŸçš„ã«ç”Ÿå­˜ä¿¡å·ã‚’é€ä¿¡
 		if (m_frame > frameCycle) {
 			OSCReceiver::SendAlive();
 			m_frame = 0;

--- a/vmt_driver/CommunicationManager.cpp
+++ b/vmt_driver/CommunicationManager.cpp
@@ -29,8 +29,12 @@ SOFTWARE.
 #include "DirectOSC.h"
 
 namespace VMTDriver {
-	//åˆ¥ã‚¹ãƒ¬ãƒƒãƒ‰
-	void OSCReceiver::SetPose(bool roomToDriver, int idx, int enable, double x, double y, double z, double qx, double qy, double qz, double qw, double timeoffset, int jointMode, const char* root_sn)
+	//•ÊƒXƒŒƒbƒh
+	void OSCReceiver::SetPose(bool roomToDriver, int idx, int enable,
+	                          double x, double y, double z,
+	                          double qx, double qy, double qz, double qw,
+	                          double timeoffset,
+	                          const char* root_sn, ReferMode_t mode)
 	{
 		RawPose pose;
 		pose.roomToDriver = roomToDriver;
@@ -44,7 +48,7 @@ namespace VMTDriver {
 		pose.qz = qz;
 		pose.qw = qw;
 		pose.timeoffset = timeoffset;
-		pose.jointMode = static_cast<JointMode_t>(jointMode);
+		pose.mode = mode;
 		pose.root_sn = root_sn;
 
 		ServerTrackedDeviceProvider* server = CommunicationManager::GetInstance()->GetServer();
@@ -92,7 +96,7 @@ namespace VMTDriver {
 	}
 
 
-	//åˆ¥ã‚¹ãƒ¬ãƒƒãƒ‰
+	//•ÊƒXƒŒƒbƒh
 	void OSCReceiver::ProcessMessage(const osc::ReceivedMessage& m, const IpEndpointName& remoteEndpoint)
 	{
 		try {
@@ -139,25 +143,47 @@ namespace VMTDriver {
 			}
 			else if (adr == "/VMT/Joint/Unity")
 			{
-				int idx, enable, jointMode;
+				int idx, enable;
 				float timeoffset;
 				float x, y, z, qx, qy, qz, qw;
 				const char* root_sn = nullptr;
 				osc::ReceivedMessageArgumentStream args = m.ArgumentStream();
-				args >> idx >> enable >> timeoffset >> x >> y >> z >> qx >> qy >> qz >> qw >> jointMode >> root_sn >> osc::EndMessage;
+				args >> idx >> enable >> timeoffset >> x >> y >> z >> qx >> qy >> qz >> qw >> root_sn >> osc::EndMessage;
 
-				SetPose(false, idx, enable, x, y, -z, qx, qy, -qz, -qw, timeoffset, jointMode, root_sn);
+				SetPose(false, idx, enable, x, y, -z, qx, qy, -qz, -qw, timeoffset, root_sn, ReferMode_t::Joint);
 			}
 			else if (adr == "/VMT/Joint/Driver")
 			{
-				int idx, enable, jointMode;
+				int idx, enable;
 				float timeoffset;
 				float x, y, z, qx, qy, qz, qw;
 				const char* root_sn = nullptr;
 				osc::ReceivedMessageArgumentStream args = m.ArgumentStream();
-				args >> idx >> enable >> timeoffset >> x >> y >> z >> qx >> qy >> qz >> qw >> jointMode >> root_sn >> osc::EndMessage;
+				args >> idx >> enable >> timeoffset >> x >> y >> z >> qx >> qy >> qz >> qw >> root_sn >> osc::EndMessage;
 
-				SetPose(false, idx, enable, x, y, z, qx, qy, qz, qw, timeoffset, jointMode, root_sn);
+				SetPose(false, idx, enable, x, y, z, qx, qy, qz, qw, timeoffset, root_sn, ReferMode_t::Joint);
+			}
+			else if (adr == "/VMT/Follow/Unity")
+			{
+				int idx, enable;
+				float timeoffset;
+				float x, y, z, qx, qy, qz, qw;
+				const char* root_sn = nullptr;
+				osc::ReceivedMessageArgumentStream args = m.ArgumentStream();
+				args >> idx >> enable >> timeoffset >> x >> y >> z >> qx >> qy >> qz >> qw >> root_sn >> osc::EndMessage;
+
+				SetPose(false, idx, enable, x, y, -z, qx, qy, -qz, -qw, timeoffset, root_sn, ReferMode_t::Follow);
+			}
+			else if (adr == "/VMT/Follow/Driver")
+			{
+				int idx, enable;
+				float timeoffset;
+				float x, y, z, qx, qy, qz, qw;
+				const char* root_sn = nullptr;
+				osc::ReceivedMessageArgumentStream args = m.ArgumentStream();
+				args >> idx >> enable >> timeoffset >> x >> y >> z >> qx >> qy >> qz >> qw >> root_sn >> osc::EndMessage;
+
+				SetPose(false, idx, enable, x, y, z, qx, qy, qz, qw, timeoffset, root_sn, ReferMode_t::Follow);
 			}
 			else if (adr == "/VMT/Input/Button")
 			{
@@ -203,11 +229,11 @@ namespace VMTDriver {
 			}
 			else if (adr == "/VMT/Reset")
 			{
-			//å…¨ãƒˆãƒ©ãƒƒã‚«ãƒ¼ã‚’0ã«ã™ã‚‹
+			//‘Sƒgƒ‰ƒbƒJ[‚ð0‚É‚·‚é
 				ServerTrackedDeviceProvider* sever = CommunicationManager::GetInstance()->GetServer();
 				for (int i = 0; i < sever->GetDevices().size(); i++)
 				{
-					sever->GetDevices()[i].Reset(); //ã™ã§ã«VRã‚·ã‚¹ãƒ†ãƒ ã«ç™»éŒ²æ¸ˆã¿ã®ã‚‚ã®ã ã‘é€šçŸ¥ã•ã‚Œã‚‹
+					sever->GetDevices()[i].Reset(); //‚·‚Å‚ÉVRƒVƒXƒeƒ€‚É“o˜^Ï‚Ý‚Ì‚à‚Ì‚¾‚¯’Ê’m‚³‚ê‚é
 				}
 			}
 			else if (adr == "/VMT/LoadSetting")
@@ -344,7 +370,7 @@ namespace VMTDriver {
 	}
 	void CommunicationManager::Process()
 	{
-		//å®šæœŸçš„ã«ç”Ÿå­˜ä¿¡å·ã‚’é€ä¿¡
+		//’èŠú“I‚É¶‘¶M†‚ð‘—M
 		if (m_frame > frameCycle) {
 			OSCReceiver::SendAlive();
 			m_frame = 0;

--- a/vmt_driver/CommunicationManager.cpp
+++ b/vmt_driver/CommunicationManager.cpp
@@ -47,11 +47,11 @@ namespace VMTDriver {
 		pose.jointMode = jointMode;
 		pose.root_sn = root_sn;
 
-		ServerTrackedDeviceProvider* sever = CommunicationManager::GetInstance()->GetServer();
-		if (idx >= 0 && idx <= sever->GetDevices().size())
+		ServerTrackedDeviceProvider* server = CommunicationManager::GetInstance()->GetServer();
+		if (idx >= 0 && idx <= server->GetDevices().size())
 		{
-			sever->GetDevices()[idx].RegisterToVRSystem(enable); //1=Tracker, 2=controller
-			sever->GetDevices()[idx].SetRawPose(pose);
+			server->GetDevices()[idx].RegisterToVRSystem(enable); //1=Tracker, 2=controller
+			server->GetDevices()[idx].SetRawPose(pose);
 		}
 	}
 

--- a/vmt_driver/CommunicationManager.h
+++ b/vmt_driver/CommunicationManager.h
@@ -29,7 +29,12 @@ namespace VMTDriver {
 
 	class OSCReceiver : public osc::OscPacketListener {
 	private:
-		void SetPose(bool roomToDriver, int idx, int enable, double x, double y, double z, double qx, double qy, double qz, double qw, double timeoffset, int jointMode = 0, const char* root_sn = nullptr);
+		void SetPose(bool roomToDriver, int idx, int enable,
+		             double x, double y, double z,
+		             double qx, double qy, double qz, double qw,
+		             double timeoffset,
+		             const char* root_sn = nullptr,
+		             ReferMode_t mode = ReferMode_t::None);
 		virtual void ProcessMessage(const osc::ReceivedMessage& m, const IpEndpointName& remoteEndpoint);
 	public:
 		static void OSCReceiver::SendLog(int stat, string msg);

--- a/vmt_driver/CommunicationManager.h
+++ b/vmt_driver/CommunicationManager.h
@@ -29,7 +29,7 @@ namespace VMTDriver {
 
 	class OSCReceiver : public osc::OscPacketListener {
 	private:
-		void SetPose(bool roomToDriver, int idx, int enable, double x, double y, double z, double qx, double qy, double qz, double qw, double timeoffset, const char* root_sn = nullptr);
+		void SetPose(bool roomToDriver, int idx, int enable, double x, double y, double z, double qx, double qy, double qz, double qw, double timeoffset, int jointMode = 0, const char* root_sn = nullptr);
 		virtual void ProcessMessage(const osc::ReceivedMessage& m, const IpEndpointName& remoteEndpoint);
 	public:
 		static void OSCReceiver::SendLog(int stat, string msg);

--- a/vmt_driver/TrackedDeviceServerDriver.cpp
+++ b/vmt_driver/TrackedDeviceServerDriver.cpp
@@ -119,7 +119,8 @@ namespace VMTDriver {
 
                 if (SerialNumber.compare(m_rawPose.root_sn) != 0) continue;
 
-                pose.result = (ETrackingResult)(p->eTrackingResult);
+                if (pose.result != ETrackingResult::TrackingResult_Calibrating_OutOfRange)
+                    pose.result = (ETrackingResult)(p->eTrackingResult);
 
                 if (p->eTrackingResult == ETrackingResult::TrackingResult_Running_OK) {
                     float* m = (float*)p->mDeviceToAbsoluteTracking.m;

--- a/vmt_driver/TrackedDeviceServerDriver.cpp
+++ b/vmt_driver/TrackedDeviceServerDriver.cpp
@@ -86,7 +86,7 @@ namespace VMTDriver {
         pose.qRotation.z = m_rawPose.qz;
         pose.qRotation.w = m_rawPose.qw;
 
-        if (m_rawPose.root_sn == nullptr) {
+        if (m_rawPose.mode == ReferMode_t::None) {
             //ワールド・ドライバ変換行列を設定
             Eigen::Translation3d pos(RoomToDriverAffin.translation());
             Eigen::Quaterniond rot(RoomToDriverAffin.rotation());
@@ -97,11 +97,10 @@ namespace VMTDriver {
             pose.qWorldFromDriverRotation.y = rot.y();
             pose.qWorldFromDriverRotation.z = rot.z();
             pose.qWorldFromDriverRotation.w = rot.w();
-        }
-        else {
-            // 既存のトラッキングデバイスの座標系でぶら下げる
+        } else {
+            // 既存のトラッキングデバイスの座標系を参照する
 
-            // ぶら下げる元のPoseを取得
+            // 参照元のPoseを取得
             vr::TrackedDevicePose_t poses[k_unMaxTrackedDeviceCount];
             IVRServerDriverHost* host = VRServerDriverHost();
             host->GetRawTrackedDevicePoses(0.0f, poses, k_unMaxTrackedDeviceCount);
@@ -119,29 +118,32 @@ namespace VMTDriver {
 
                 if (SerialNumber.compare(m_rawPose.root_sn) != 0) continue;
 
-                if (pose.result != ETrackingResult::TrackingResult_Calibrating_OutOfRange)
-                    pose.result = (ETrackingResult)(p->eTrackingResult);
+                // 参照元のトラッキングステータスを継承させる
+                if (m_rawPose.enable != 0) {
+                    pose.result = p->eTrackingResult;
+                }
 
                 if (p->eTrackingResult == ETrackingResult::TrackingResult_Running_OK) {
                     float* m = (float*)p->mDeviceToAbsoluteTracking.m;
 
-                    Eigen::Affine3d mm;
-                    mm.matrix() << m[0 * 4 + 0], m[0 * 4 + 1], m[0 * 4 + 2], m[0 * 4 + 3],
+                    Eigen::Affine3d rootDeviceToAbsoluteTracking;
+                    rootDeviceToAbsoluteTracking.matrix() <<
+                        m[0 * 4 + 0], m[0 * 4 + 1], m[0 * 4 + 2], m[0 * 4 + 3],
                         m[1 * 4 + 0], m[1 * 4 + 1], m[1 * 4 + 2], m[1 * 4 + 3],
                         m[2 * 4 + 0], m[2 * 4 + 1], m[2 * 4 + 2], m[2 * 4 + 3],
                         0.0, 0.0, 0.0, 1.0;
 
-                    Eigen::Translation3d pos(mm.translation());
+                    Eigen::Translation3d pos(rootDeviceToAbsoluteTracking.translation());
                     pose.vecWorldFromDriverTranslation[0] = pos.x();
                     pose.vecWorldFromDriverTranslation[1] = pos.y();
                     pose.vecWorldFromDriverTranslation[2] = pos.z();
 
                     Eigen::Quaterniond rot;
-                    switch (m_rawPose.jointMode) {
-                    case JointMode_t::JointPositionJointRotation:
-                        rot = Eigen::Quaterniond(mm.rotation());
+                    switch (m_rawPose.mode) {
+                    case ReferMode_t::Joint:
+                        rot = Eigen::Quaterniond(rootDeviceToAbsoluteTracking.rotation());
                         break;
-                    case JointMode_t::JointPositionRoomRotation: // IMUトラッカー用（重力・地磁気共にジョイント元の状態に寄らずにIMUの座標系で取得される）
+                    case ReferMode_t::Follow:
                         rot = Eigen::Quaterniond(RoomToDriverAffin.rotation());
                         break;
                     default:

--- a/vmt_driver/TrackedDeviceServerDriver.cpp
+++ b/vmt_driver/TrackedDeviceServerDriver.cpp
@@ -138,11 +138,14 @@ namespace VMTDriver {
 
                     Eigen::Quaterniond rot;
                     switch (m_rawPose.jointMode) {
-                    case 1: // 回転は追従させない（ジェイロIMUに都合のいいモード）
+                    case JointMode_t::JointPositionJointRotation:
+                        rot = Eigen::Quaterniond(mm.rotation());
+                        break;
+                    case JointMode_t::JointPositionRoomRotation: // IMUトラッカー用（重力・地磁気共にジョイント元の状態に寄らずにIMUの座標系で取得される）
                         rot = Eigen::Quaterniond(RoomToDriverAffin.rotation());
                         break;
                     default:
-                        rot = Eigen::Quaterniond(mm.rotation());
+                        rot = Eigen::Quaterniond::Identity();
                         break;
                     }
 

--- a/vmt_driver/TrackedDeviceServerDriver.cpp
+++ b/vmt_driver/TrackedDeviceServerDriver.cpp
@@ -131,10 +131,20 @@ namespace VMTDriver {
                         0.0, 0.0, 0.0, 1.0;
 
                     Eigen::Translation3d pos(mm.translation());
-                    Eigen::Quaterniond rot(mm.rotation());
                     pose.vecWorldFromDriverTranslation[0] = pos.x();
                     pose.vecWorldFromDriverTranslation[1] = pos.y();
                     pose.vecWorldFromDriverTranslation[2] = pos.z();
+
+                    Eigen::Quaterniond rot;
+                    switch (m_rawPose.jointMode) {
+                    case 1: // 回転は追従させない（ジェイロIMUに都合のいいモード）
+                        rot = Eigen::Quaterniond(RoomToDriverAffin.rotation());
+                        break;
+                    default:
+                        rot = Eigen::Quaterniond(mm.rotation());
+                        break;
+                    }
+
                     pose.qWorldFromDriverRotation.x = rot.x();
                     pose.qWorldFromDriverRotation.y = rot.y();
                     pose.qWorldFromDriverRotation.z = rot.z();

--- a/vmt_driver/TrackedDeviceServerDriver.h
+++ b/vmt_driver/TrackedDeviceServerDriver.h
@@ -39,6 +39,7 @@ namespace VMTDriver {
         double qz;
         double qw;
         double timeoffset;
+        int jointMode;
         const char* root_sn;
     };
 

--- a/vmt_driver/TrackedDeviceServerDriver.h
+++ b/vmt_driver/TrackedDeviceServerDriver.h
@@ -27,6 +27,15 @@ SOFTWARE.
 namespace VMTDriver {
     const HmdQuaternion_t HmdQuaternion_Identity{ 1,0,0,0 };
 
+    enum JointMode_t : int {
+        JointPositionJointRotation = 0x00000000,
+        JointPositionRoomRotation = 0x00000001,
+        
+        // No reason to implements
+        // RoomPositionJointRotation = 0x00000100,
+        // RoomPositionRoomRotation = 0x00000101,
+    };
+
     struct RawPose {
         bool roomToDriver;
         int idx;
@@ -39,11 +48,11 @@ namespace VMTDriver {
         double qz;
         double qw;
         double timeoffset;
-        int jointMode;
+        JointMode_t jointMode;
         const char* root_sn;
     };
 
-    //個々のデバイス
+    //蛟九�縺ｮ繝�繝舌う繧ｹ
     class TrackedDeviceServerDriver : public ITrackedDeviceServerDriver
     {
     private:

--- a/vmt_driver/TrackedDeviceServerDriver.h
+++ b/vmt_driver/TrackedDeviceServerDriver.h
@@ -27,15 +27,6 @@ SOFTWARE.
 namespace VMTDriver {
     const HmdQuaternion_t HmdQuaternion_Identity{ 1,0,0,0 };
 
-    enum JointMode_t : int {
-        JointPositionJointRotation = 0x00000000,
-        JointPositionRoomRotation = 0x00000001,
-        
-        // No reason to implements
-        // RoomPositionJointRotation = 0x00000100,
-        // RoomPositionRoomRotation = 0x00000101,
-    };
-
     struct RawPose {
         bool roomToDriver;
         int idx;
@@ -48,11 +39,11 @@ namespace VMTDriver {
         double qz;
         double qw;
         double timeoffset;
-        JointMode_t jointMode;
+        ReferMode_t mode;
         const char* root_sn;
     };
 
-    //蛟九�縺ｮ繝�繝舌う繧ｹ
+    //個々のデバイス
     class TrackedDeviceServerDriver : public ITrackedDeviceServerDriver
     {
     private:

--- a/vmt_driver/dllmain.h
+++ b/vmt_driver/dllmain.h
@@ -50,6 +50,12 @@ namespace VMTDriver {
 	class TrackedDeviceServerDriver;
 	class VRWatchdogProvider;
 	class Log;
+
+	enum ReferMode_t : int {
+		None = 0,   // ルーム座標を使用する
+		Joint = 1,  // Position, Rotation共に他のトラッカーデバイスの座標系を参照する
+		Follow = 2, // Positionは他のトラッカーデバイスを参照するが、Rotationはルーム座標を参照する
+	};
 }
 
 namespace DirectOSC {


### PR DESCRIPTION
現行のJointモードの場合、Position, Rotationともジョイント先の座標変換の影響を受ける。

特に、IMUを使ったトラッカーをJointする場合、IMUの回転系はジョイント先の状態に依らず、
重力（≒ルーム座標系）によって系が定まっているため、Rotationに関しては、Joint先の座標系とルーム座標系の
どちらを参照するか切り替え可能とした。


また、Positionの切り替えについても考えられるが、用途が思いつかなかったため未実装とした。